### PR TITLE
feat: FIREBASE_TOKEN is not mandatory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,5 +9,5 @@ runs:
   main: 'dist/index.js'
 inputs:
   firebase-token:
-    required: true
+    required: false
     description: Firebase token you can get by running `firebase login:ci`

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,12 +9,10 @@ const run = async () => {
   const token = core.getInput('firebase-token')
   const os = process.env.RUNNER_OS
 
-  if (!token) {
-    throw new Error('Missing mandatory input: firebase-token')
+  if (token) {
+    core.exportVariable('FIREBASE_TOKEN', token)
+    core.info('Exported environment variable FIREBASE_TOKEN')
   }
-
-  core.exportVariable('FIREBASE_TOKEN', token)
-  core.info('Exported environment variable FIREBASE_TOKEN')
 
   if (await commandExists('npm')) {
     core.info('Detected NPM installation')


### PR DESCRIPTION
Firebase can use Google application default authentication, which means you don't need FIREBASE_TOKEN.

See https://github.com/google-github-actions/auth
